### PR TITLE
Add BuildContext extension generator code for shorter provider access

### DIFF
--- a/slang/lib/builder/generator/generate_header.dart
+++ b/slang/lib/builder/generator/generate_header.dart
@@ -302,6 +302,18 @@ void _generateTranslationGetter({
     buffer.writeln(
         '\tstatic InheritedLocaleData<$enumName, $baseClassName> of(BuildContext context) => InheritedLocaleData.of<$enumName, $baseClassName>(context);');
     buffer.writeln('}');
+
+    // BuildContext extension for provider
+    buffer.writeln();
+    buffer.writeln('/// Method C: BuildContext extension');
+    buffer.writeln('///');
+    buffer.writeln('/// For a shorter alternative to `TranslationProvider.of(context)`, a BuildContext extension is provided:');
+    buffer.writeln('///');
+    buffer.writeln('/// Usage (e.g. in a widget\'s `build` method:');
+    buffer.writeln('/// context.tr.someKey.anotherKey');
+    buffer.writeln('extension BuildContextTranslationsExtension on BuildContext {');
+    buffer.writeln('  $baseClassName get tr => TranslationProvider.of(this).translations;');
+    buffer.writeln('}');
   }
 }
 

--- a/slang/lib/builder/generator/generator.dart
+++ b/slang/lib/builder/generator/generator.dart
@@ -12,8 +12,10 @@ class Generator {
     required List<I18nData> translations,
   }) {
     final header = generateHeader(config, translations);
-    final list = Map.fromEntries(translations
-        .map((t) => MapEntry(t.locale, generateTranslations(config, t))));
+    final list = {
+      for (final t in translations)
+        t.locale: generateTranslations(config, t),
+    };
     final String? flatMap;
     if (config.renderFlatMap) {
       flatMap = generateTranslationMap(config, translations);

--- a/slang/test/integration/resources/main/expected_main.output
+++ b/slang/test/integration/resources/main/expected_main.output
@@ -80,6 +80,16 @@ class TranslationProvider extends BaseTranslationProvider<AppLocale, _Translatio
 	static InheritedLocaleData<AppLocale, _TranslationsEn> of(BuildContext context) => InheritedLocaleData.of<AppLocale, _TranslationsEn>(context);
 }
 
+/// Method C: BuildContext extension
+///
+/// For a shorter alternative to `TranslationProvider.of(context)`, a BuildContext extension is provided:
+///
+/// Usage (e.g. in a widget's `build` method:
+/// context.tr.someKey.anotherKey
+extension BuildContextTranslationsExtension on BuildContext {
+  _TranslationsEn get tr => TranslationProvider.of(this).translations;
+}
+
 /// Manages all translation instances and the current locale
 class LocaleSettings extends BaseFlutterLocaleSettings<AppLocale, _TranslationsEn> {
 	LocaleSettings._() : super(

--- a/slang/test/integration/resources/main/expected_single.output
+++ b/slang/test/integration/resources/main/expected_single.output
@@ -76,6 +76,16 @@ class TranslationProvider extends BaseTranslationProvider<AppLocale, _Translatio
 	static InheritedLocaleData<AppLocale, _TranslationsEn> of(BuildContext context) => InheritedLocaleData.of<AppLocale, _TranslationsEn>(context);
 }
 
+/// Method C: BuildContext extension
+///
+/// For a shorter alternative to `TranslationProvider.of(context)`, a BuildContext extension is provided:
+///
+/// Usage (e.g. in a widget's `build` method:
+/// context.tr.someKey.anotherKey
+extension BuildContextTranslationsExtension on BuildContext {
+  _TranslationsEn get tr => TranslationProvider.of(this).translations;
+}
+
 /// Manages all translation instances and the current locale
 class LocaleSettings extends BaseFlutterLocaleSettings<AppLocale, _TranslationsEn> {
 	LocaleSettings._() : super(


### PR DESCRIPTION
This adds a simple `BuildContext` extension to be generated, so that users may now do

```dart
context.tr.someKey.anotherKey;
```

instead of

```dart
Translations.of(context).someKey.anotherKey;
```