### PR TITLE
add `unnecessary_string_interpolations` and `avoid_escaping_inner_quotes`

### DIFF
--- a/slang/example/lib/i18n/strings.g.dart
+++ b/slang/example/lib/i18n/strings.g.dart
@@ -8,7 +8,7 @@
  * Built on 2022-05-31 at 23:50 UTC
  */
 
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, library_private_types_in_public_api
+// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, library_private_types_in_public_api, unnecessary_string_interpolations
 
 import 'package:flutter/widgets.dart';
 import 'package:slang_flutter/slang_flutter.dart';

--- a/slang/example/lib/i18n/strings.g.dart
+++ b/slang/example/lib/i18n/strings.g.dart
@@ -8,7 +8,7 @@
  * Built on 2022-05-31 at 23:50 UTC
  */
 
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, library_private_types_in_public_api, unnecessary_string_interpolations
+// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, library_private_types_in_public_api, unnecessary_string_interpolations, avoid_escaping_inner_quotes
 
 import 'package:flutter/widgets.dart';
 import 'package:slang_flutter/slang_flutter.dart';

--- a/slang/lib/builder/generator/generate_header.dart
+++ b/slang/lib/builder/generator/generate_header.dart
@@ -111,7 +111,7 @@ void _generateHeaderComment({
 
   buffer.writeln();
   buffer.writeln(
-      '// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, library_private_types_in_public_api, unnecessary_string_interpolations');
+      '// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, library_private_types_in_public_api, unnecessary_string_interpolations, avoid_escaping_inner_quotes');
 }
 
 void _generateImports(I18nConfig config, StringBuffer buffer) {

--- a/slang/lib/builder/generator/generate_header.dart
+++ b/slang/lib/builder/generator/generate_header.dart
@@ -111,7 +111,7 @@ void _generateHeaderComment({
 
   buffer.writeln();
   buffer.writeln(
-      '// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, library_private_types_in_public_api');
+      '// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, library_private_types_in_public_api, unnecessary_string_interpolations');
 }
 
 void _generateImports(I18nConfig config, StringBuffer buffer) {


### PR DESCRIPTION
To avoid warnings in such case:

```
one: hello
two: '@:one'
```

and avoid warnings when having such input:

```
one: "Tom's thing" 
```