### PR TITLE
Replace `flutter pub run` with `dart run`

### DIFF
--- a/slang/MIGRATION.md
+++ b/slang/MIGRATION.md
@@ -77,9 +77,9 @@ translate_var: t
 
 ### Command
 
-If you generate via `flutter pub run fast_i18n`, please make sure to call `slang` instead.
+If you generate via `dart run fast_i18n`, please make sure to call `slang` instead.
 
-`flutter pub run slang`
+`dart run slang`
 
 ## fast_i18n 4.0 to 5.0
 

--- a/slang/README.md
+++ b/slang/README.md
@@ -160,7 +160,7 @@ Built-in:
 ```text
 # Recommended during development. It runs much faster than build_runner.
 
-flutter pub run slang
+dart run slang
 ```
 
 Alternative (requires [slang_build_runner](https://pub.dev/packages/slang_build_runner)):
@@ -168,7 +168,7 @@ Alternative (requires [slang_build_runner](https://pub.dev/packages/slang_build_
 ```text
 # Useful for CI and initial git checkout.
 
-flutter pub run build_runner build -d
+dart run build_runner build -d
 ```
 
 **Step 4: Initialize**
@@ -328,7 +328,7 @@ imports:
 <details>
   <summary>build.yaml (Click to open example)</summary>
 
-Using `build.yaml` is **necessary** if you use `build_runner`. It has a higher compatibility as `flutter pub run slang` also recognizes this file.
+Using `build.yaml` is **necessary** if you use `build_runner`. It has a higher compatibility as `dart run slang` also recognizes this file.
 
 ```yaml
 targets:
@@ -1350,7 +1350,7 @@ flutter_integration: false # set this
 The main command to generate dart files from translation resources.
 
 ```sh
-flutter pub run slang
+dart run slang
 ```
 
 ### ➤ Analyze Translations
@@ -1360,7 +1360,7 @@ You can use the slang analyzer to find missing and unused translations.
 Missing translations only occur when `fallback_strategy: base_locale` is used.
 
 ```sh
-flutter pub run slang analyze [--split] [--full] [--outdir=assets/i18n]
+dart run slang analyze [--split] [--full] [--outdir=assets/i18n]
 ```
 
 | Argument          | Usage                                                  |
@@ -1395,7 +1395,7 @@ It reads the `_missing_translations` file and adds the translations to the origi
 Currently, only JSON and YAML are supported.
 
 ```sh
-flutter pub run slang apply [--locale=fr-FR] [--outdir=assets/i18n]
+dart run slang apply [--locale=fr-FR] [--outdir=assets/i18n]
 ```
 
 | Argument            | Usage                                                  |
@@ -1410,7 +1410,7 @@ You want to update an existing string, but you want to keep the old translations
 Here, you can run a simple command to flag translations as `OUTDATED`. They will show up in `_missing_translations` when running `analyze`.
 
 ```sh
-flutter pub run slang outdated a.b.c
+dart run slang outdated a.b.c
 ```
 
 This will add an `(OUTDATED)` modifier to all secondary locales.
@@ -1434,7 +1434,7 @@ There are some tools to make migration from other i18n solutions easier.
 General migration syntax:
 
 ```sh
-flutter pub run slang migrate <type> <source> <destination>
+dart run slang migrate <type> <source> <destination>
 ```
 
 #### ARB
@@ -1442,7 +1442,7 @@ flutter pub run slang migrate <type> <source> <destination>
 Transforms ARB files to compatible JSON format. All descriptions are retained.
 
 ```sh
-flutter pub run slang migrate arb source.arb destination.json
+dart run slang migrate arb source.arb destination.json
 ```
 
 ARB Input
@@ -1497,7 +1497,7 @@ JSON Result
 There is a command to quickly get the number of words, characters, etc.
 
 ```sh
-flutter pub run slang stats
+dart run slang stats
 ```
 
 Example console output:
@@ -1516,7 +1516,7 @@ You can let the library rebuild automatically for you.
 The watch function from `build_runner` is **NOT** maintained.
 
 ```sh
-flutter pub run slang watch
+dart run slang watch
 ```
 
 ## Integrations

--- a/slang/bin/slang.dart
+++ b/slang/bin/slang.dart
@@ -27,7 +27,7 @@ enum RunnerMode {
 }
 
 /// To run this:
-/// -> flutter pub run slang
+/// -> dart run slang
 ///
 /// Scans translation files and builds the dart file.
 /// This is usually faster than the build_runner implementation.

--- a/slang/example/slang.yaml
+++ b/slang/example/slang.yaml
@@ -1,5 +1,5 @@
 # The slang config file which works without build_runner.
-# 'flutter pub run slang' will pick up this file.
+# 'dart run slang' will pick up this file.
 # In this example, no configuration is needed.
 #
 # base_locale: en

--- a/slang/lib/runner/analyze.dart
+++ b/slang/lib/runner/analyze.dart
@@ -53,12 +53,12 @@ void runAnalyzeTranslations({
       return [
         'Here are translations that exist in <${rawConfig.baseLocale.languageTag}> but not in ${locale != null ? '<${locale.languageTag}>' : 'secondary locales'}.',
         if (locale != null)
-          'After editing this file, you can run \'flutter pub run slang apply --locale=${locale.languageTag}\' to quickly apply the newly added translations.'
+          'After editing this file, you can run \'dart run slang apply --locale=${locale.languageTag}\' to quickly apply the newly added translations.'
         else if (localeMap.length > 1)
           // there are at least 2 secondary locales
-          'After editing this file, you can run \'flutter pub run slang apply --locale=<locale>\' to quickly apply the newly added translations.'
+          'After editing this file, you can run \'dart run slang apply --locale=<locale>\' to quickly apply the newly added translations.'
         else
-          'After editing this file, you can run \'flutter pub run slang apply\' to quickly apply the newly added translations.',
+          'After editing this file, you can run \'dart run slang apply\' to quickly apply the newly added translations.',
       ];
     },
     result: missingTranslationsResult,
@@ -88,7 +88,7 @@ void runAnalyzeTranslations({
             'Here are translations that exist in <${locale.languageTag}> but not in <${rawConfig.baseLocale.languageTag}>.',
         ],
         if (!full)
-          'You may run \'flutter pub run slang analyze --full\' to also check translations not used in the source code.',
+          'You may run \'dart run slang analyze --full\' to also check translations not used in the source code.',
       ];
     },
     result: unusedTranslationsResult,

--- a/slang_build_runner/README.md
+++ b/slang_build_runner/README.md
@@ -31,5 +31,5 @@ targets:
 The generate command:
 
 ```text
-flutter pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs
 ```


### PR DESCRIPTION
Running `flutter pub run ...` with Flutter 3.10 gives us this output:

```
$ flutter pub run slang
Deprecated. Use `dart run` instead.
Building package executable... (1.6s)
Built slang:slang.
Generating translations...

```