### PR TITLE
add cache translate_var variable

### DIFF
--- a/slang/lib/builder/generator/generate_header.dart
+++ b/slang/lib/builder/generator/generate_header.dart
@@ -318,8 +318,9 @@ void _generateTranslationGetter({
     buffer.writeln(
         '/// String b = $translateVar[\'someKey.anotherKey\']; // Only for edge cases!');
   }
+  buffer.writeln('$baseClassName? _$translateVar;');
   buffer.writeln(
-      '$baseClassName get $translateVar => LocaleSettings.instance.currentTranslations;');
+      '$baseClassName get $translateVar => _$translateVar ??= LocaleSettings.instance.currentTranslations;');
 
   // t getter (advanced)
   if (config.flutterIntegration) {


### PR DESCRIPTION
Hi!

Thank you for this great library!

I've encountered a performance problem due to the fact that 'translate_var' is recalculated on each call, the locale is extracted each time.

Testing,
```dart
       for (var i = 0; i < 500000; i++) {
            var tr = t.somelabel;          
        }
```
Time taken: 2628 ms
vs:
```dart
       final itl = t;
       for (var i = 0; i < 500000; i++) {
            var tr = itl.somelabel;          
        }
```
Time taken: 1595 ms

For my part, I use the "translation_class_visibility: public" flag to create an intermediate cache, but doing so or proposing it at library level would be a plus.

So, in this merge request, I'm adding a private cache variable. Its reset on setLocale() calls is missing, hence the partial nature of this merge request, as I don't know what would be the best approach.

I look forward to hearing from you soon and thank you,

Alexandre